### PR TITLE
Add function hoisting and fix unary +/- type checking for strings

### DIFF
--- a/src/analysis/checkers/typeCompatibility.ts
+++ b/src/analysis/checkers/typeCompatibility.ts
@@ -184,6 +184,8 @@ export class TypeCompatibilityChecker {
           // Boolean operand becomes integer, others stay the same
           return operandType === UcodeType.BOOLEAN ? UcodeType.INTEGER : operandType;
         }
+        // Unary +/- on strings performs numeric conversion (e.g., +"42" → 42, +"abc" → NaN)
+        if (operandType === UcodeType.STRING) return UcodeType.DOUBLE;
         return UcodeType.UNKNOWN;
       case '!':
         // Logical NOT can be applied to any type (truthy/falsy evaluation)

--- a/src/analysis/semanticAnalyzer.ts
+++ b/src/analysis/semanticAnalyzer.ts
@@ -166,8 +166,26 @@ export class SemanticAnalyzer extends BaseVisitor {
   }
 
   visitProgram(node: ProgramNode): void {
+    // Hoist top-level function declarations so forward references resolve
+    this.hoistFunctionDeclarations(node);
     // Global scope analysis
     super.visitProgram(node);
+  }
+
+  /**
+   * Pre-register all top-level function declarations in the symbol table
+   * so that forward references (calling a function before its declaration) work.
+   */
+  private hoistFunctionDeclarations(node: ProgramNode): void {
+    if (!this.options.enableScopeAnalysis) return;
+    for (const stmt of node.body) {
+      if (stmt.type === 'FunctionDeclaration') {
+        const funcNode = stmt as FunctionDeclarationNode;
+        if (funcNode.id && funcNode.id.name) {
+          this.symbolTable.declare(funcNode.id.name, SymbolType.FUNCTION, UcodeType.FUNCTION as UcodeDataType, funcNode.id);
+        }
+      }
+    }
   }
 
   visitVariableDeclaration(node: VariableDeclarationNode): void {
@@ -796,15 +814,19 @@ export class SemanticAnalyzer extends BaseVisitor {
     if (this.options.enableScopeAnalysis) {
       const name = node.id.name;
 
-      // Declare the function first with an UNKNOWN return type to handle recursion.
-      if (!this.symbolTable.declare(name, SymbolType.FUNCTION, UcodeType.FUNCTION as UcodeDataType, node.id)) {
-        this.addDiagnosticErrorCode(
-          UcodeErrorCode.FUNCTION_REDECLARATION,
-          `Function '${name}' is already declared in this scope`,
-          node.id.start,
-          node.id.end,
-          DiagnosticSeverity.Error
-        );
+      // Declare the function (may already exist from hoisting pre-pass).
+      const existing = this.symbolTable.lookup(name);
+      const alreadyHoisted = existing && existing.type === SymbolType.FUNCTION;
+      if (!alreadyHoisted) {
+        if (!this.symbolTable.declare(name, SymbolType.FUNCTION, UcodeType.FUNCTION as UcodeDataType, node.id)) {
+          this.addDiagnosticErrorCode(
+            UcodeErrorCode.FUNCTION_REDECLARATION,
+            `Function '${name}' is already declared in this scope`,
+            node.id.start,
+            node.id.end,
+            DiagnosticSeverity.Error
+          );
+        }
       }
 
       // Set context for nested return statement analysis.

--- a/src/analysis/typeChecker.ts
+++ b/src/analysis/typeChecker.ts
@@ -538,10 +538,13 @@ export class TypeChecker {
     switch (operator) {
       case '+':
       case '-':
+        // Unary +/- perform numeric conversion on strings (e.g., +"42" → 42)
+        // This is valid in ucode, same as JavaScript behavior
+        return operandType === UcodeType.ARRAY || operandType === UcodeType.OBJECT;
       case '++':
       case '--':
         // These require numeric types or booleans (which coerce to integers)
-        return operandType === UcodeType.STRING || 
+        return operandType === UcodeType.STRING ||
                operandType === UcodeType.ARRAY || operandType === UcodeType.OBJECT;
       case '~':
         // Bitwise complement requires integer type or booleans (which coerce to integers)


### PR DESCRIPTION
## Summary
- **Function hoisting**: Pre-register top-level function declarations so forward references (calling a function before its declaration) resolve correctly, matching ucode/JavaScript semantics
- **Unary +/- on strings**: Allow unary `+`/`-` operators on string operands (numeric coercion) instead of flagging as type errors — e.g., `+"42"` correctly evaluates to a number

## Test plan
- [ ] Verify that forward function references no longer produce "undeclared function" diagnostics
- [ ] Verify that `+"42"` and `-"42"` no longer produce type errors
- [ ] Verify that unary `++`/`--` on strings still correctly flags as a type error
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)