### PR TITLE
fix: add param definitions for export top level functions

### DIFF
--- a/src/parser/statements/declarationStatements.ts
+++ b/src/parser/statements/declarationStatements.ts
@@ -15,9 +15,9 @@ import { ExpressionParser } from '../expressions/expressionParser';
 
 export abstract class DeclarationStatements extends ExpressionParser {
 
-  protected parseVariableDeclaration(): VariableDeclarationNode {
+  protected parseVariableDeclaration(jsdocAnchorPos?: number): VariableDeclarationNode {
     const start = this.previous()!.pos;
-    const leadingJsDoc = this.findLeadingJsDoc(start);
+    const leadingJsDoc = this.findLeadingJsDoc(jsdocAnchorPos ?? start);
     const kind = this.previous()!.type === TokenType.TK_CONST ? 'const' : 'let';
     const declarations: VariableDeclaratorNode[] = [];
 
@@ -79,9 +79,9 @@ export abstract class DeclarationStatements extends ExpressionParser {
     };
   }
 
-  protected parseFunctionDeclaration(isExported: boolean = false): FunctionDeclarationNode | FunctionExpressionNode | null {
+  protected parseFunctionDeclaration(isExported: boolean = false, jsdocAnchorPos?: number): FunctionDeclarationNode | FunctionExpressionNode | null {
     const start = this.previous()!.pos;
-    const leadingJsDoc = this.findLeadingJsDoc(start);
+    const leadingJsDoc = this.findLeadingJsDoc(jsdocAnchorPos ?? start);
 
     // For export default functions, the name is optional (anonymous functions allowed)
     let id: IdentifierNode | null = null;
@@ -329,7 +329,7 @@ export abstract class DeclarationStatements extends ExpressionParser {
 
     // Check for export default
     if (this.match(TokenType.TK_DEFAULT)) {
-      const declaration = this.parseExportDefaultDeclaration();
+      const declaration = this.parseExportDefaultDeclaration(start);
       if (!declaration) return null;
 
       return {
@@ -355,9 +355,9 @@ export abstract class DeclarationStatements extends ExpressionParser {
       let declaration: AstNode | null = null;
       
       if (this.match(TokenType.TK_FUNC)) {
-        declaration = this.parseFunctionDeclaration(true); // Exported function
+        declaration = this.parseFunctionDeclaration(true, start); // Exported function
       } else if (this.match(TokenType.TK_LOCAL, TokenType.TK_CONST)) {
-        declaration = this.parseVariableDeclaration();
+        declaration = this.parseVariableDeclaration(start);
       }
 
       if (!declaration) return null;
@@ -376,10 +376,10 @@ export abstract class DeclarationStatements extends ExpressionParser {
     return null;
   }
 
-  private parseExportDefaultDeclaration(): AstNode | null {
+  private parseExportDefaultDeclaration(jsdocAnchorPos?: number): AstNode | null {
     // For export default, we can export a function or expression
     if (this.match(TokenType.TK_FUNC)) {
-      return this.parseFunctionDeclaration(true); // Exported function
+      return this.parseFunctionDeclaration(true, jsdocAnchorPos); // Exported function
     } else {
       // Parse as expression
       const expr = this.parseExpression();

--- a/tests/test-jsdoc-annotations.js
+++ b/tests/test-jsdoc-annotations.js
@@ -265,6 +265,43 @@ describe('JSDoc Type Annotations', function() {
       const missingAnnotations = diagnostics.filter(d => d.message.includes('unknown type'));
       assert.strictEqual(missingAnnotations.length, 0, 'Should not warn for parameterless functions');
     });
+
+    it('should attach JSDoc to exported function declarations (no warning)', async () => {
+      const diagnostics = await getDiagnostics(`'use strict';
+        /** @param {string} method
+         *  @param {string} path
+         *  @param {string|null} body */
+        export function build_request(method, path, body) {
+          return method;
+        };
+      `, '/tmp/jsdoc-uc7003-export.uc');
+      const missingAnnotations = diagnostics.filter(d => d.message.includes('unknown type'));
+      assert.strictEqual(missingAnnotations.length, 0,
+        `Exported function JSDoc should be attached, got: ${diagnostics.map(d => d.message).join('; ')}`);
+    });
+
+    it('should still warn for exported function with no JSDoc (strict mode)', async () => {
+      const diagnostics = await getDiagnostics(`'use strict';
+        export function build_request(method, path, body) {
+          return method;
+        };
+      `, '/tmp/jsdoc-uc7003-export-nojsdoc.uc');
+      const missingAnnotations = diagnostics.filter(d => d.message.includes('unknown type'));
+      assert.ok(missingAnnotations.length >= 1,
+        `Exported function without JSDoc should still warn, got: ${diagnostics.map(d => d.message).join('; ')}`);
+    });
+
+    it('should attach JSDoc to export default function declarations (no warning)', async () => {
+      const diagnostics = await getDiagnostics(`'use strict';
+        /** @param {string} x */
+        export default function helper(x) {
+          return x;
+        };
+      `, '/tmp/jsdoc-uc7003-export-default.uc');
+      const missingAnnotations = diagnostics.filter(d => d.message.includes('unknown type'));
+      assert.strictEqual(missingAnnotations.length, 0,
+        `Export default function JSDoc should be attached, got: ${diagnostics.map(d => d.message).join('; ')}`);
+    });
   });
 
   // === Bare module name tests ===


### PR DESCRIPTION
I had problems within vscode with exported top level functions.

This code gives a wrong UC7003 note:

```ucode
/**
 * Extract HTTP status code from the start of a response buffer.
 *
 * @param {string} buf       Buffer that begins with the status line
 * @returns {number}         Status code, or 0 if the line doesn't match
 */
export function parse_status(buf) {
	let m = match(buf, /^HTTP\/[0-9.]+ ([0-9]+)/);
	return m ? +m[1] : 0;
};
```

but this works:

```ucode
/**
 * Extract HTTP status code from the start of a response buffer.
 *
 * @param {string} buf       Buffer that begins with the status line
 * @returns {number}         Status code, or 0 if the line doesn't match
 */
function parse_status(buf) {
	let m = match(buf, /^HTTP\/[0-9.]+ ([0-9]+)/);
	return m ? +m[1] : 0;
};
```

This PR fix it. Tested the server against an existing ucode file and added some testing code too. I am not so familiar with LSPs so i tried my best, but could be that it should be solved in an other way - maybe not and this PR helps you a bit 🙂 

Would be really nice if you can check it out and if all is fine an update will come so i get rid of the (wrong) linting messages 😉 

greetz & thanks for your work 🫶 